### PR TITLE
Adding a license file

### DIFF
--- a/license.md
+++ b/license.md
@@ -8,12 +8,12 @@ This End User License Agreement ("EULA") is a legal agreement between you and Da
 This EULA grants you the following limited, non-exclusive rights to the Software, subject to the terms and conditions set forth in this EULA:
 1. Your license rights under this EULA are non-exclusive, non-transferrable, and non-sublicenseable.
 2. You may install and use the Software for internal and example purposes only provided that:
-  1. you ensure all copyright notices are retained in any copies made for your example purposes;
-  2. you indemnify, hold harmless, and defend DataStax, Inc. from and against any claims or lawsuits, including attorney's fees, that arise as a result from the use of the Software.
+    1. you ensure all copyright notices are retained in any copies made for your example purposes;
+    2. you indemnify, hold harmless, and defend DataStax, Inc. from and against any claims or lawsuits, including attorney's fees, that arise as a result from the use of the Software.
 3. You may view, modify and compile the Source Code; provided that:
-  1. you ensure all copyright notices are retained;
-  2. The Source Code is used for internal and example purposes only; and
-  3. you indemnify, hold harmless, and defend DataStax, Inc. from and against any claims or lawsuits, including attorney's fees, that arise as a result from the use or distribution of the Software
+    1. you ensure all copyright notices are retained;
+    2. The Source Code is used for internal and example purposes only; and
+    3. you indemnify, hold harmless, and defend DataStax, Inc. from and against any claims or lawsuits, including attorney's fees, that arise as a result from the use or distribution of the Software
 
 ### 3. LICENSE RESTRICTIONS
 1. Other than as set forth in Section 2, you may not make or distribute copies of the Software.

--- a/license.md
+++ b/license.md
@@ -1,0 +1,42 @@
+## END-USER LICENSE AGREEMENT:   EXAMPLE CODE FOR USE WITH DATASTAX ENTERPRISE
+This End User License Agreement ("EULA") is a legal agreement between you and DataStax, Inc. for the software product identified above, which includes the software and any associated documentation (collectively, the "Software"). Please read this EULA carefully. By downloading, installing, copying, modifying, distributing, or otherwise using the Software, you acknowledge that you have read the EULA and agree to its terms. If you are agreeing to these terms on behalf of a company or other legal entity, you represent that you have the legal authority to bind the legal entity to these terms. If you do not have such authority, or you do not wish to be bound by the terms of this EULA, then you must not use the Software.
+
+### 1. DEFINITIONS
+1. "Source Code" means the source files provided as part of the Software.
+
+### 2. SOFTWARE LICENSE GRANT
+This EULA grants you the following limited, non-exclusive rights to the Software, subject to the terms and conditions set forth in this EULA:
+1. Your license rights under this EULA are non-exclusive, non-transferrable, and non-sublicenseable.
+2. You may install and use the Software for internal and example purposes only provided that:
+  1. you ensure all copyright notices are retained in any copies made for your example purposes;
+  2. you indemnify, hold harmless, and defend DataStax, Inc. from and against any claims or lawsuits, including attorney's fees, that arise as a result from the use of the Software.
+3. You may view, modify and compile the Source Code; provided that:
+  1. you ensure all copyright notices are retained;
+  2. The Source Code is used for internal and example purposes only; and
+  3. you indemnify, hold harmless, and defend DataStax, Inc. from and against any claims or lawsuits, including attorney's fees, that arise as a result from the use or distribution of the Software
+
+### 3. LICENSE RESTRICTIONS
+1. Other than as set forth in Section 2, you may not make or distribute copies of the Software.
+2. Other than as set forth in Section 2, you may not alter, merge, modify, adapt or translate the Software, or decompile, reverse engineer, disassemble, or otherwise reduce the Software to a human-perceivable form.
+3. You may not use the Software or Source Code for any third-party product or use the Software or Source Code in any production system or other end user-facing environment.
+4. Except as expressly permitted under this EULA, you agree not to assign, distribute, transfer, lease, modify, or create derivative works of the Software or Source Code, in whole or in part, or permit or authorize a third party to do so, and any transfer must be subject to written agreement by the recipient of the terms of this EULA.
+
+### 4. COPYRIGHT AND INTELLECTUAL PROPERTY RIGHTS
+The Software is protected by copyright laws and international copyright treaties, as well as other intellectual property laws and treaties. The Software is licensed, not sold. DataStax, Inc. retains title, ownership, and all associated intellectual property of Software. You will not delete or in any manner alter the copyright, trademark, and other proprietary rights notices or markings appearing on the Software as delivered to you. If the Software is being used by or on behalf of the U.S. Government, then the U.S. Government's rights in them will be only those specified in this EULA, consistent with FAR 12.212 and DFARS 227.7202-1 through 227.7202-4, as applicable. Furthermore, this EULA does not grant you any rights in connection with any trademarks or service marks of DataStax, Inc. DataStax, Inc. reserves all intellectual property rights, including copyrights, and trademark rights.
+
+### 5. DISCLAIMER OF WARRANTIES
+Unless required by applicable law or agreed to in writing, DataStax, Inc. provides the Software on an "as-is" basis. DataStax does not provide support or services of any kind for the Software.  EXCEPT AS EXPRESSLY PROVIDED IN THIS EULA, DATASTAX, INC. PROVIDES NO OTHER WARRANTIES REGARDING THE SOFTWARE, AND TO THE FULLEST EXTENT PERMITTED BY LAW DISCLAIMS ALL OTHER WARRANTIES, TERMS AND CONDITIONS, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO ANY IMPLIED WARRANTIES AND CONDITIONS OF MERCHANTABILITY, QUALITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT, AND ANY WARRANTIES, TERMS AND CONDITIONS ARISING OUT OF COURSE OF DEALING OR USAGE OF TRADE. NO ADVICE OR INFORMATION, WHETHER ORAL OR WRITTEN, OBTAINED FROM DATASTAX, INC. OR ELSEWHERE WILL CREATE ANY WARRANTY, TERM OR CONDITION UNLESS EXPRESSLY STATED IN THIS EULA.
+
+### 6. LIMITATION OF LIABILITY
+To the fullest extent permitted by applicable law, in no event shall DataStax, Inc. be liable for the cost of procurement of substitute goods or technology, loss of profits, or for any special, consequential, incidental, punitive or indirect damages on any theory of liability, whether in contract, tort, strict liability or otherwise, even if advised of the possibility of such damages. To the fullest extent permitted by applicable law, in no event shall the total liability of DataStax to you under this EULA exceed one hundred US dollars ($100.00).
+
+### 7. TERMINATION
+This EULA is effective until terminated. DataStax, Inc. reserves the right, in its sole discretion, to terminate this EULA upon 30-days' notice. This EULA and any license rights granted hereunder will terminate immediately without notice from DataStax, Inc. if you fail to comply with any provision of this EULA. Upon termination, you must destroy all copies of Software.
+
+### 8. MISCELLANEOUS
+1. Assignment: You may not assign this EULA by operation of law or otherwise. DataStax, Inc. may assign this EULA upon written notice.
+2. Entire Agreement: This EULA constitutes the complete agreement between the parties and supersedes all prior or contemporaneous agreements or representations, written or oral, concerning the subject matter of this EULA. No modification of this EULA will be binding on DataStax, Inc., unless in writing and signed by an authorized representative of DataStax.
+3. Export Controls: By using the Software, you agree to comply with all import, export, and re-export restrictions and regulations of the United States and other countries.
+4. Governing Law: This EULA is to be construed in accordance with the laws of the State of California and controlling U.S. federal laws, without regard to the choice of law rules of any jurisdiction.
+5. Severability and Waiver: If any provision of this EULA (or any portion hereof) is held to be unenforceable, this EULA will remain in effect with the provision omitted, unless omission would frustrate the intent of the parties. The waiver by either party of any default or breach of this EULA will not constitute a waiver of any other or subsequent default or breach.
+


### PR DESCRIPTION
This license file was created and approved by DataStax Legal and generally allows for use of this source code within internal, demo environments. 

This commit message does not offer full description of the license nor does it have any governance over what is contained in the license file. Please refer to license.md for actual usage details. 